### PR TITLE
Include usage-rules.md in package/files

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -78,6 +78,7 @@ defmodule TermUI.MixProject do
         README.md
         LICENSE
         CHANGELOG.md
+        usage-rules.md
       )
     ]
   end


### PR DESCRIPTION
This change to mix.exs forces `usage-rules.md` to be included in the TermUI package.  This is required for [UsageRules](https://hexdocs.pm/usage_rules/readme.html) to find the TermUI content when running `mix usage_rules.sync ... --all`. 