### PR TITLE
Fix Theme.style_from_theme/4 calling undefined Style.from/1

### DIFF
--- a/lib/term_ui/renderer/style.ex
+++ b/lib/term_ui/renderer/style.ex
@@ -309,6 +309,14 @@ defmodule TermUI.Renderer.Style do
     a.fg == b.fg and a.bg == b.bg and MapSet.equal?(a.attrs, b.attrs)
   end
 
+  @doc """
+  Checks if style has an attribute.
+  """
+  @spec has_attr?(t(), attribute()) :: boolean()
+  def has_attr?(%__MODULE__{} = style, attr) do
+    MapSet.member?(style.attrs, attr)
+  end
+
   # Private validation helpers
 
   defp validate_color!(nil), do: nil

--- a/lib/term_ui/theme.ex
+++ b/lib/term_ui/theme.ex
@@ -425,7 +425,7 @@ defmodule TermUI.Theme do
   @spec style_from_theme(atom(), atom(), keyword(), GenServer.server()) :: Style.t()
   def style_from_theme(component, variant, overrides \\ [], server \\ __MODULE__) do
     base = get_component_style(component, variant, server) || Style.new()
-    override_style = Style.from(overrides)
+    override_style = Style.new(overrides)
     Style.merge(base, override_style)
   end
 

--- a/test/term_ui/theme_integration_test.exs
+++ b/test/term_ui/theme_integration_test.exs
@@ -1,7 +1,7 @@
 defmodule TermUI.ThemeIntegrationTest do
   use ExUnit.Case, async: true
 
-  alias TermUI.Style
+  alias TermUI.Renderer.Style
   alias TermUI.Theme
 
   setup do

--- a/test/term_ui/theme_test.exs
+++ b/test/term_ui/theme_test.exs
@@ -1,7 +1,7 @@
 defmodule TermUI.ThemeTest do
   use ExUnit.Case, async: true
 
-  alias TermUI.Style
+  alias TermUI.Renderer.Style
   alias TermUI.Theme
 
   setup do


### PR DESCRIPTION
## Summary

- Fix production bug where `Theme.style_from_theme/4` crashed with `UndefinedFunctionError` because it called `Style.from/1` which doesn't exist in `TermUI.Renderer.Style`
- Add `has_attr?/2` to `TermUI.Renderer.Style` for API parity
- Update test aliases to match the actual return type (`TermUI.Renderer.Style`)

## Details

`theme.ex` aliases `TermUI.Renderer.Style` as `Style`, but line 428 was calling `Style.from(overrides)`. This function only exists in `TermUI.Style`, not `TermUI.Renderer.Style`. Changed to `Style.new(overrides)` which exists and accepts the same keyword list argument.

## Test plan

- [x] Existing theme tests now pass
- [x] No new test failures introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)