### PR TITLE
Fix Regex module attributes for Elixir 1.18 compatibility

### DIFF
--- a/lib/term_ui/sanitize.ex
+++ b/lib/term_ui/sanitize.ex
@@ -29,15 +29,19 @@ defmodule TermUI.Sanitize do
       "Normal text"
   """
 
-  @ansi_escape_pattern ~r/(\x1b\[
-                         [0-9;:=?]*[
-                         \x40-\x7e]|
-                         \x1b\]
-                         [^\x07\x1b]*\x07|
-                         \x1b[^\x1b\x07]|
-                         \x07[\x05\x06]|
-                         \x00-\x08|\x0b-\x0c|\x0e-\x1f
-                       )/x
+  # NOTE: Defined as a function rather than a module attribute because compiled
+  # Regex structs contain references that cannot be injected into function bodies.
+  defp ansi_escape_pattern do
+    ~r/(\x1b\[
+         [0-9;:=?]*[
+         \x40-\x7e]|
+         \x1b\]
+         [^\x07\x1b]*\x07|
+         \x1b[^\x1b\x07]|
+         \x07[\x05\x06]|
+         \x00-\x08|\x0b-\x0c|\x0e-\x1f
+       )/x
+  end
 
   # Dialyzer: Functions return specific atom types
   @dialyzer {:nowarn_function, validate: 1}
@@ -93,7 +97,7 @@ defmodule TermUI.Sanitize do
   """
   @spec has_ansi?(binary()) :: boolean()
   def has_ansi?(input) when is_binary(input) do
-    Regex.match?(@ansi_escape_pattern, input)
+    Regex.match?(ansi_escape_pattern(), input)
   end
 
   @doc """
@@ -109,7 +113,7 @@ defmodule TermUI.Sanitize do
   """
   @spec strip_ansi(binary()) :: binary()
   def strip_ansi(input) when is_binary(input) do
-    Regex.replace(@ansi_escape_pattern, input, "")
+    Regex.replace(ansi_escape_pattern(), input, "")
   end
 
   @doc """
@@ -191,7 +195,7 @@ defmodule TermUI.Sanitize do
   end
 
   defp sanitize_escapes(input, :remove) do
-    Regex.replace(@ansi_escape_pattern, input, "")
+    Regex.replace(ansi_escape_pattern(), input, "")
   end
 
   defp sanitize_escapes(input, :keep), do: input

--- a/lib/term_ui/widget/block.ex
+++ b/lib/term_ui/widget/block.ex
@@ -30,12 +30,16 @@ defmodule TermUI.Widget.Block do
   # Dialyzer: Suppress opaque type warnings for Style helpers
   # Dialyzer: no_return warnings for functions that don't return
   # no_opaque: Style contains MapSet which triggers false positive call_without_opaque warnings
-  @dialyzer [:no_opaque,
-             nowarn_function: [build_style: 1,
-                               positioned_cell_safe: 4,
-                               do_render_top: 5,
-                               render_bottom_border: 3,
-                               render_side_borders: 3]]
+  @dialyzer [
+    :no_opaque,
+    nowarn_function: [
+      build_style: 1,
+      positioned_cell_safe: 4,
+      do_render_top: 5,
+      render_bottom_border: 3,
+      render_side_borders: 3
+    ]
+  ]
 
   # Border character sets
   @borders %{

--- a/lib/term_ui/widgets/log_viewer.ex
+++ b/lib/term_ui/widgets/log_viewer.ex
@@ -84,19 +84,25 @@ defmodule TermUI.Widgets.LogViewer do
           highlight: boolean()
         }
 
-  @level_patterns [
-    {:emergency, ~r/\b(EMERGENCY|EMERG)\b/i},
-    {:alert, ~r/\b(ALERT)\b/i},
-    {:critical, ~r/\b(CRITICAL|CRIT|FATAL)\b/i},
-    {:error, ~r/\b(ERROR|ERR)\b/i},
-    {:warning, ~r/\b(WARNING|WARN)\b/i},
-    {:notice, ~r/\b(NOTICE)\b/i},
-    {:info, ~r/\b(INFO)\b/i},
-    {:debug, ~r/\b(DEBUG|DBG)\b/i}
-  ]
+  # NOTE: Regex patterns defined as functions rather than module attributes because
+  # compiled Regex structs contain references that cannot be injected into function bodies.
+  defp level_patterns do
+    [
+      {:emergency, ~r/\b(EMERGENCY|EMERG)\b/i},
+      {:alert, ~r/\b(ALERT)\b/i},
+      {:critical, ~r/\b(CRITICAL|CRIT|FATAL)\b/i},
+      {:error, ~r/\b(ERROR|ERR)\b/i},
+      {:warning, ~r/\b(WARNING|WARN)\b/i},
+      {:notice, ~r/\b(NOTICE)\b/i},
+      {:info, ~r/\b(INFO)\b/i},
+      {:debug, ~r/\b(DEBUG|DBG)\b/i}
+    ]
+  end
 
-  @timestamp_pattern ~r/\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?/
-  @source_pattern ~r/\[([^\]]+)\]/
+  defp timestamp_pattern,
+    do: ~r/\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?/
+
+  defp source_pattern, do: ~r/\[([^\]]+)\]/
 
   @page_size 20
 
@@ -891,7 +897,7 @@ defmodule TermUI.Widgets.LogViewer do
   end
 
   defp extract_timestamp(line) do
-    case Regex.run(@timestamp_pattern, line) do
+    case Regex.run(timestamp_pattern(), line) do
       [match | _] ->
         case DateTime.from_iso8601(match) do
           {:ok, dt, _} -> dt
@@ -904,13 +910,13 @@ defmodule TermUI.Widgets.LogViewer do
   end
 
   defp extract_level(line) do
-    Enum.find_value(@level_patterns, fn {level, pattern} ->
+    Enum.find_value(level_patterns(), fn {level, pattern} ->
       if Regex.match?(pattern, line), do: level, else: nil
     end)
   end
 
   defp extract_source(line) do
-    case Regex.run(@source_pattern, line) do
+    case Regex.run(source_pattern(), line) do
       [_, source | _] -> source
       nil -> nil
     end

--- a/lib/term_ui/widgets/process_monitor.ex
+++ b/lib/term_ui/widgets/process_monitor.ex
@@ -98,15 +98,19 @@ defmodule TermUI.Widgets.ProcessMonitor do
   @sort_fields [:pid, :name, :reductions, :memory, :queue, :status]
 
   # System process patterns to optionally hide
-  @system_patterns [
-    ~r/^:application_controller$/,
-    ~r/^:kernel_sup$/,
-    ~r/^:code_server$/,
-    ~r/^:file_server/,
-    ~r/^:init$/,
-    ~r/^:logger/,
-    ~r/^:erl_prim_loader$/
-  ]
+  # NOTE: Defined as a function rather than a module attribute because compiled
+  # Regex structs contain references that cannot be injected into function bodies.
+  defp system_patterns do
+    [
+      ~r/^:application_controller$/,
+      ~r/^:kernel_sup$/,
+      ~r/^:code_server$/,
+      ~r/^:file_server/,
+      ~r/^:init$/,
+      ~r/^:logger/,
+      ~r/^:erl_prim_loader$/
+    ]
+  end
 
   # ----------------------------------------------------------------------------
   # Style Helper Functions
@@ -468,7 +472,7 @@ defmodule TermUI.Widgets.ProcessMonitor do
   defp maybe_filter_system(processes, false) do
     Enum.reject(processes, fn p ->
       name = process_name(p)
-      Enum.any?(@system_patterns, &Regex.match?(&1, name))
+      Enum.any?(system_patterns(), &Regex.match?(&1, name))
     end)
   end
 

--- a/test/term_ui/runtime_test.exs
+++ b/test/term_ui/runtime_test.exs
@@ -594,5 +594,4 @@ defmodule TermUI.RuntimeTest do
       assert state.input_state == nil
     end
   end
-
 end


### PR DESCRIPTION
## Summary
- Converted Regex module attributes (`@system_patterns`, `@level_patterns`, `@timestamp_pattern`, `@source_pattern`, `@ansi_escape_pattern`) to private functions in `ProcessMonitor`, `LogViewer`, and `Sanitize` modules.
- Compiled `Regex` structs contain Erlang references that Elixir 1.18 cannot inject from module attributes into function bodies at compile time, causing `ArgumentError: cannot escape #Reference<...>`.

These are the minimal changes needed to compile and run on Elixir 1.18.

## Test plan
- [x] `mix deps.compile term_ui --force` succeeds
- [x] No behavioral changes — only moves compile-time regexes to runtime function calls