### PR TITLE
Optimize terminal rendering with run coalescing and O(n) diffing

### DIFF
--- a/lib/term_ui/backend/raw.ex
+++ b/lib/term_ui/backend/raw.ex
@@ -736,13 +736,15 @@ defmodule TermUI.Backend.Raw do
   end
 
   def draw_cells(state, cells) when is_list(cells) do
-    # Group cells by row and process each row with a reset at the end
-    # This prevents style bleeding from one row to the next
+    # Sort cells in row-major order, then by column within each row
+    sorted_cells =
+      Enum.sort_by(cells, fn {{row, col}, _cell} -> {row, col} end)
+
+    # Split into contiguous runs and render each with a single cursor position
+    runs = detect_runs(sorted_cells)
+
     {output, final_pos, final_style} =
-      cells
-      |> Enum.group_by(fn {{row, _col}, _cell} -> row end)
-      |> Enum.sort()
-      |> process_cells_by_row(state.cursor_position, state.current_style)
+      render_runs(runs, state.cursor_position, state.current_style)
 
     # Write batched output to terminal
     write_to_terminal(output)
@@ -753,43 +755,61 @@ defmodule TermUI.Backend.Raw do
     {:ok, updated_state}
   end
 
-  # Process cells grouped by row, emitting a reset after each row
-  defp process_cells_by_row(rows_with_cells, initial_pos, initial_style) do
-    Enum.reduce(rows_with_cells, {[], initial_pos, initial_style}, fn {_row, cells},
-                                                                            {output_acc,
-                                                                             cursor_pos, style} ->
-      # Sort cells within row by column
-      sorted_cells = Enum.sort_by(cells, fn {{_row, col}, _cell} -> col end)
+  # Detects contiguous runs of cells: same row with consecutive columns.
+  # Returns a list of runs, where each run is a non-empty list of cells
+  # that can be rendered with a single cursor positioning.
+  defp detect_runs([]), do: []
 
-      # Process all cells in this row
-      {row_output, row_end_pos, _row_end_style} =
-        process_row_cells(sorted_cells, cursor_pos, style)
+  defp detect_runs([first | rest]) do
+    {current_run, runs} =
+      Enum.reduce(rest, {[first], []}, fn {{row, col}, _cell_data} = cell,
+                                          {current_run, completed_runs} ->
+        # Get the last cell in the current run to check adjacency
+        [{{prev_row, prev_col}, _} | _] = current_run
 
-      # Append row output and reset after row to prevent style bleeding
-      {[output_acc, row_output, ANSI.reset()], row_end_pos, nil}
+        if row == prev_row and col == prev_col + 1 do
+          # Adjacent: extend current run (prepend for efficiency, reversed later)
+          {[cell | current_run], completed_runs}
+        else
+          # Gap or new row: finalize current run, start new one
+          {[cell], [Enum.reverse(current_run) | completed_runs]}
+        end
+      end)
+
+    # Don't forget the final run
+    Enum.reverse([Enum.reverse(current_run) | runs])
+  end
+
+  # Renders a list of runs into an iolist. Each run gets one cursor position
+  # at its start, then streams characters with inline style deltas only when
+  # the style changes. Style state is tracked continuously across runs (no
+  # per-row resets).
+  defp render_runs(runs, initial_pos, initial_style) do
+    Enum.reduce(runs, {[], initial_pos, initial_style}, fn run, {output_acc, cursor_pos, style} ->
+      {run_output, run_end_pos, run_end_style} =
+        render_single_run(run, cursor_pos, style)
+
+      {[output_acc, run_output], run_end_pos, run_end_style}
     end)
   end
 
-  # Process cells within a single row
-  defp process_row_cells(cells, initial_pos, initial_style) do
-    Enum.reduce(cells, {[], initial_pos, initial_style}, fn {{row, col} = target_pos,
-                                                              {char, fg, bg, attrs}},
-                                                             {output_acc, cursor_pos, style} ->
-      # Generate cursor movement if needed
-      cursor_output = cursor_move_output(cursor_pos, target_pos)
+  # Renders a single contiguous run. Emits one cursor position at the start,
+  # then for each cell: style delta (if changed) + character.
+  defp render_single_run([{{row, col}, _} | _] = run, cursor_pos, style) do
+    # Position cursor at run start
+    cursor_output = cursor_move_output(cursor_pos, {row, col})
 
-      # Generate style delta
-      new_style = %{fg: fg, bg: bg, attrs: normalize_attrs(attrs)}
-      style_output = style_delta_output(style, new_style)
+    # Stream characters with inline style changes
+    {chars_output, end_col, end_style} =
+      Enum.reduce(run, {[], col, style}, fn {{_row, _col}, {char, fg, bg, attrs}},
+                                            {out_acc, cur_col, cur_style} ->
+        new_style = %{fg: fg, bg: bg, attrs: normalize_attrs(attrs)}
+        style_output = style_delta_output(cur_style, new_style)
 
-      # Build cell output: [cursor_move, style_delta, character]
-      cell_output = [cursor_output, style_output, char]
+        {[out_acc, style_output, char], cur_col + 1, new_style}
+      end)
 
-      # After outputting character, cursor advances one column
-      new_cursor_pos = {row, col + 1}
-
-      {[output_acc, cell_output], new_cursor_pos, new_style}
-    end)
+    {[cursor_output, chars_output], {row, end_col}, end_style}
   end
 
   # Normalizes attributes to a sorted list for consistent comparison.

--- a/lib/term_ui/runtime.ex
+++ b/lib/term_ui/runtime.ex
@@ -469,11 +469,14 @@ defmodule TermUI.Runtime do
     # Enable ONLCR translation (bare \n → \r\n) since raw mode disables OPOST
     TerminalOutput.enable_onlcr()
 
+    # Terminal GenServer already entered alternate screen and hid cursor in
+    # setup_terminal_and_buffers, so skip those here to avoid double entry.
+    # Mouse tracking is also already configured.
     {:ok, backend_state} =
       backend.init(
-        alternate_screen: true,
-        hide_cursor: true,
-        mouse_tracking: :all,
+        alternate_screen: false,
+        hide_cursor: false,
+        mouse_tracking: :none,
         size: {cols, rows}
       )
 
@@ -482,7 +485,7 @@ defmodule TermUI.Runtime do
 
   defp init_tty_backend(capabilities) do
     backend = TermUI.Backend.TTY
-    {:ok, backend_state} = backend.init(capabilities: capabilities)
+    {:ok, backend_state} = backend.init(capabilities: capabilities, alternate_screen: true)
     {:tty, backend, backend_state, capabilities, false, nil, nil}
   end
 
@@ -495,29 +498,32 @@ defmodule TermUI.Runtime do
   end
 
   defp setup_terminal_and_buffers do
-    # Start Terminal GenServer first, before calling any Terminal API functions
-    # The Terminal GenServer will detect if raw mode is already active (e.g., from Selector)
-    with {:ok, _pid} <- Terminal.start_link(),
-         :ok <- Terminal.enter_alternate_screen(),
-         :ok <- Terminal.hide_cursor(),
-         :ok <- Terminal.enable_mouse_tracking(:all),
-         {rows, cols} <- get_terminal_dimensions_safe(),
-         {:ok, buffer_pid} <- BufferManager.start_link(rows: rows, cols: cols) do
-      {true, buffer_pid, {cols, rows}}
-    else
-      {:error, {:already_started, buffer_pid}} ->
-        # BufferManager already started, use it
-        {rows, cols} = get_terminal_dimensions_safe()
-        {true, buffer_pid, {cols, rows}}
-
-      {:error, _reason} ->
-        {false, nil, nil}
-
-      _ ->
-        {false, nil, nil}
+    # Start Terminal GenServer (or reuse if already running)
+    case Terminal.start_link() do
+      {:ok, _pid} -> :ok
+      {:error, {:already_started, _pid}} -> :ok
+      {:error, reason} -> throw({:terminal_failed, reason})
     end
+
+    # Configure terminal for TUI mode
+    :ok = Terminal.enter_alternate_screen()
+    :ok = Terminal.hide_cursor()
+    :ok = Terminal.enable_mouse_tracking(:all)
+
+    {rows, cols} = get_terminal_dimensions_safe()
+
+    # Start BufferManager (or reuse if already running)
+    buffer_pid =
+      case BufferManager.start_link(rows: rows, cols: cols) do
+        {:ok, pid} -> pid
+        {:error, {:already_started, pid}} -> pid
+      end
+
+    {true, buffer_pid, {cols, rows}}
   rescue
     _ -> {false, nil, nil}
+  catch
+    {:terminal_failed, _} -> {false, nil, nil}
   end
 
   defp get_terminal_dimensions_safe do
@@ -1225,62 +1231,76 @@ defmodule TermUI.Runtime do
         current_row = Buffer.get_row(current, row)
         previous_row = Buffer.get_row(previous, row)
 
-        current_changed = find_current_changed_cells(current_row, previous_row, row)
-        previous_changed = find_previous_cells_to_clear(current_row, previous_row, row)
-
-        current_changed ++ previous_changed ++ acc
+        # Single O(n) zip pass instead of two O(n^2) passes with Enum.at
+        diff_row_cells(current_row, previous_row, row, 1, acc)
     end
   end
 
-  defp find_current_changed_cells(current_row, previous_row, row) do
-    current_row
-    |> Enum.with_index(1)
-    |> Enum.filter(fn {cell, col} ->
-      displayable_cell?(cell) and cell_changed_from_previous?(cell, col, previous_row)
-    end)
-    |> Enum.flat_map(fn {cell, col} ->
-      cell_to_backend_tuple(cell, row, col)
-    end)
+  # Zips current and previous rows in a single pass, emitting:
+  # - Changed displayable cells (new content to draw)
+  # - Clear cells (previous content that needs erasing)
+  defp diff_row_cells([], [], _row, _col, acc), do: acc
+
+  defp diff_row_cells([cur | cur_rest], [prev | prev_rest], row, col, acc) do
+    acc =
+      if Cell.equal?(cur, prev) do
+        # Identical — skip
+        acc
+      else
+        # Cells differ — check what to emit
+        cur_displayable = displayable_cell?(cur)
+        prev_displayable = displayable_cell?(prev)
+
+        acc =
+          if cur_displayable do
+            # New content to draw
+            cell_to_backend_tuple(cur, row, col) ++ acc
+          else
+            acc
+          end
+
+        if prev_displayable and not cur_displayable do
+          # Previous had content, current is empty — need to clear
+          [{{row, col}, {" ", :default, :default, []}} | acc]
+        else
+          if prev_displayable and cur_displayable and
+               prev.bg != nil and prev.bg != :default and cur.char == " " do
+            # Previous had colored bg, current is space — clear to remove bg
+            [{{row, col}, {" ", :default, :default, []}} | acc]
+          else
+            acc
+          end
+        end
+      end
+
+    diff_row_cells(cur_rest, prev_rest, row, col + 1, acc)
   end
 
-  defp cell_changed_from_previous?(cell, col, previous_row) do
-    prev_cell = Enum.at(previous_row, col - 1, Cell.empty())
-    not Cell.equal?(cell, prev_cell)
+  # Handle rows of different lengths (shouldn't happen normally, but be safe)
+  defp diff_row_cells([cur | cur_rest], [], row, col, acc) do
+    acc =
+      if displayable_cell?(cur) do
+        cell_to_backend_tuple(cur, row, col) ++ acc
+      else
+        acc
+      end
+
+    diff_row_cells(cur_rest, [], row, col + 1, acc)
   end
 
-  defp find_previous_cells_to_clear(current_row, previous_row, row) do
-    previous_row
-    |> Enum.with_index(1)
-    |> Enum.filter(fn {prev_cell, col} ->
-      displayable_cell?(prev_cell) and needs_clearing_at?(col, prev_cell, current_row)
-    end)
-    |> Enum.map(fn {_prev_cell, col} ->
-      # Send a clear cell (space with default styling)
-      {{row, col}, {" ", :default, :default, []}}
-    end)
+  defp diff_row_cells([], [prev | prev_rest], row, col, acc) do
+    acc =
+      if displayable_cell?(prev) do
+        [{{row, col}, {" ", :default, :default, []}} | acc]
+      else
+        acc
+      end
+
+    diff_row_cells([], prev_rest, row, col + 1, acc)
   end
 
   defp displayable_cell?(%Cell{} = cell) do
     cell.char != " " or (cell.bg != nil and cell.bg != :default)
-  end
-
-  defp needs_clearing_at?(col, prev_cell, current_row) do
-    current_cell = Enum.at(current_row, col - 1, Cell.empty())
-    cells_differ = not Cell.equal?(current_cell, prev_cell)
-
-    # Only clear if:
-    # 1. Current cell is empty (nothing new to render), OR
-    # 2. Previous cell had colored background AND current cell has no text (just space)
-    # This prevents clearing overwriting new text content while still clearing colored backgrounds
-    had_colored_bg = prev_cell.bg != nil and prev_cell.bg != :default
-    has_no_text = current_cell.char == " "
-
-    cells_differ and (empty_cell?(current_cell) or (had_colored_bg and has_no_text))
-  end
-
-  defp empty_cell?(%Cell{} = cell) do
-    cell.char == " " and cell.bg == :default and cell.fg == :default and
-      MapSet.size(cell.attrs) == 0
   end
 
   # Converts a Cell struct to the backend format: {{row, col}, {char, fg, bg, attrs}}

--- a/lib/term_ui/terminal_output.ex
+++ b/lib/term_ui/terminal_output.ex
@@ -67,17 +67,10 @@ defmodule TermUI.TerminalOutput do
 
   @spec cleanup_sequence() :: String.t()
   def cleanup_sequence do
-    base =
-      "\e[?1006l\e[?1003l\e[?1002l\e[?1000l" <>
-        "\e[?25h" <>
-        "\e[0m" <>
-        "\e[?1049l"
-
-    if needs_hard_reset?() do
-      base <> "\ec"
-    else
-      base
-    end
+    "\e[?1006l\e[?1003l\e[?1002l\e[?1000l" <>
+      "\e[?25h" <>
+      "\e[0m" <>
+      "\e[?1049l"
   end
 
   @spec needs_hard_reset?() :: boolean()

--- a/test/term_ui/backend/raw_test.exs
+++ b/test/term_ui/backend/raw_test.exs
@@ -2086,6 +2086,336 @@ defmodule TermUI.Backend.RawTest do
   end
 
   # ===========================================================================
+  # Section: Run Coalescing Tests
+  # ===========================================================================
+
+  describe "draw_cells/2 run coalescing" do
+    import ExUnit.CaptureIO
+
+    setup do
+      key = {TermUI.TerminalOutput, :needs_hard_reset}
+      original = :persistent_term.get(key, :unset)
+      :persistent_term.put(key, false)
+
+      on_exit(fn ->
+        if original == :unset,
+          do: :persistent_term.erase(key),
+          else: :persistent_term.put(key, original)
+      end)
+
+      # Init inside capture_io to discard setup sequences (cursor hide, clear, etc.)
+      ExUnit.CaptureIO.capture_io(fn ->
+        {:ok, s} = Raw.init(size: {24, 80}, alternate_screen: false)
+        send(self(), {:state, s})
+      end)
+
+      state =
+        receive do
+          {:state, s} -> s
+        end
+
+      %{state: state}
+    end
+
+    test "adjacent cells on same row use single cursor position", %{state: state} do
+      # 3 adjacent cells: col 5, 6, 7
+      cells = [
+        {{1, 5}, {"A", :default, :default, []}},
+        {{1, 6}, {"B", :default, :default, []}},
+        {{1, 7}, {"C", :default, :default, []}}
+      ]
+
+      output =
+        capture_io(fn ->
+          {:ok, _state} = Raw.draw_cells(state, cells)
+        end)
+
+      # Should have exactly ONE cursor position sequence for this run
+      cursor_positions = Regex.scan(~r/\e\[\d+;\d+H/, output)
+      assert length(cursor_positions) == 1
+      assert output =~ "\e[1;5H"
+
+      # Characters should appear in sequence without cursor moves between them
+      assert output =~ "ABC"
+    end
+
+    test "non-adjacent cells on same row get separate cursor positions", %{state: state} do
+      # Gap between col 3 and col 10
+      cells = [
+        {{1, 3}, {"X", :default, :default, []}},
+        {{1, 10}, {"Y", :default, :default, []}}
+      ]
+
+      output =
+        capture_io(fn ->
+          {:ok, _state} = Raw.draw_cells(state, cells)
+        end)
+
+      # Should have TWO cursor position sequences (one per run)
+      cursor_positions = Regex.scan(~r/\e\[\d+;\d+H/, output)
+      assert length(cursor_positions) == 2
+      assert output =~ "\e[1;3H"
+      assert output =~ "\e[1;10H"
+    end
+
+    test "style change within a run emits inline SGR without cursor reposition", %{state: state} do
+      # Adjacent cells at col 5,6,7 (not at cursor start) with different styles
+      cells = [
+        {{1, 5}, {"R", :red, :default, []}},
+        {{1, 6}, {"G", :green, :default, []}},
+        {{1, 7}, {"B", :blue, :default, []}}
+      ]
+
+      output =
+        capture_io(fn ->
+          {:ok, _state} = Raw.draw_cells(state, cells)
+        end)
+
+      # Should have exactly ONE cursor position (start of run)
+      cursor_positions = Regex.scan(~r/\e\[\d+;\d+H/, output)
+      assert length(cursor_positions) == 1
+
+      # All three characters should be present
+      assert output =~ "R"
+      assert output =~ "G"
+      assert output =~ "B"
+    end
+
+    test "multiple runs on same row coalesce independently", %{state: state} do
+      # Two runs: cols 5-7 and cols 15-17 (neither at cursor start {1,1})
+      cells = [
+        {{1, 5}, {"A", :default, :default, []}},
+        {{1, 6}, {"B", :default, :default, []}},
+        {{1, 7}, {"C", :default, :default, []}},
+        {{1, 15}, {"X", :default, :default, []}},
+        {{1, 16}, {"Y", :default, :default, []}},
+        {{1, 17}, {"Z", :default, :default, []}}
+      ]
+
+      output =
+        capture_io(fn ->
+          {:ok, _state} = Raw.draw_cells(state, cells)
+        end)
+
+      # Exactly 2 cursor positions (one per run)
+      cursor_positions = Regex.scan(~r/\e\[\d+;\d+H/, output)
+      assert length(cursor_positions) == 2
+
+      # Characters should be streamed contiguously within each run
+      assert output =~ "ABC"
+      assert output =~ "XYZ"
+    end
+
+    test "cells across rows each get cursor position for their run", %{state: state} do
+      cells = [
+        {{2, 1}, {"A", :default, :default, []}},
+        {{2, 2}, {"B", :default, :default, []}},
+        {{3, 1}, {"C", :default, :default, []}},
+        {{3, 2}, {"D", :default, :default, []}}
+      ]
+
+      output =
+        capture_io(fn ->
+          {:ok, _state} = Raw.draw_cells(state, cells)
+        end)
+
+      # 2 cursor positions: one for row 2 run, one for row 3 run
+      cursor_positions = Regex.scan(~r/\e\[\d+;\d+H/, output)
+      assert length(cursor_positions) == 2
+      assert output =~ "\e[2;1H"
+      assert output =~ "\e[3;1H"
+      assert output =~ "AB"
+      assert output =~ "CD"
+    end
+
+    test "single cell still works correctly", %{state: state} do
+      cells = [{{5, 10}, {"Z", :red, :default, [:bold]}}]
+
+      output =
+        capture_io(fn ->
+          {:ok, result} = Raw.draw_cells(state, cells)
+          assert result.cursor_position == {5, 11}
+          assert result.current_style.fg == :red
+        end)
+
+      assert output =~ "\e[5;10H"
+      assert output =~ "Z"
+    end
+
+    test "full row of same style produces minimal output", %{state: state} do
+      # 40 adjacent cells on row 2 (not at cursor start), same style
+      cells =
+        for col <- 1..40 do
+          {{2, col}, {"X", :green, :default, []}}
+        end
+
+      output =
+        capture_io(fn ->
+          {:ok, _state} = Raw.draw_cells(state, cells)
+        end)
+
+      # Exactly 1 cursor position for the entire run
+      cursor_positions = Regex.scan(~r/\e\[\d+;\d+H/, output)
+      assert length(cursor_positions) == 1
+
+      # All 40 X characters should be contiguous
+      assert output =~ String.duplicate("X", 40)
+    end
+
+    test "run coalescing reduces byte count vs per-cell positioning", %{state: state} do
+      # 20 adjacent cells on row 5 (not at cursor start), same style - measure output size
+      cells =
+        for col <- 1..20 do
+          {{5, col}, {"A", :default, :default, []}}
+        end
+
+      output =
+        capture_io(fn ->
+          {:ok, _state} = Raw.draw_cells(state, cells)
+        end)
+
+      output_bytes = byte_size(output)
+
+      # Per-cell positioning would need ~10 bytes per cursor move * 20 cells = 200+ bytes
+      # Coalesced: 1 cursor position (~6 bytes) + 20 chars = ~26 bytes + style overhead
+      # Should be well under 100 bytes for 20 same-style chars
+      assert output_bytes < 100,
+             "Expected < 100 bytes for 20 coalesced cells, got #{output_bytes}"
+    end
+
+    test "style continuity across runs avoids redundant SGR", %{state: state} do
+      # Two separate runs with same style on row 3 (not at cursor start)
+      cells = [
+        {{3, 1}, {"A", :red, :default, [:bold]}},
+        {{3, 2}, {"B", :red, :default, [:bold]}},
+        # gap
+        {{3, 10}, {"C", :red, :default, [:bold]}},
+        {{3, 11}, {"D", :red, :default, [:bold]}}
+      ]
+
+      output =
+        capture_io(fn ->
+          {:ok, _state} = Raw.draw_cells(state, cells)
+        end)
+
+      # Style is set once at the beginning; second run should NOT re-emit the same style
+      # Count red foreground sequences (SGR 31)
+      red_seqs = Regex.scan(~r/\e\[31m/, output)
+      assert length(red_seqs) == 1, "Expected 1 red fg sequence, got #{length(red_seqs)}"
+    end
+
+    test "no per-row style reset when style continues", %{state: state} do
+      # Same style across two rows - should not emit reset between them
+      cells = [
+        {{3, 1}, {"A", :red, :default, []}},
+        {{4, 1}, {"B", :red, :default, []}}
+      ]
+
+      output =
+        capture_io(fn ->
+          {:ok, _state} = Raw.draw_cells(state, cells)
+        end)
+
+      # Should NOT contain any ESC[0m reset sequences
+      reset_count = length(Regex.scan(~r/\e\[0m/, output))
+
+      assert reset_count == 0,
+             "Expected 0 resets for same-style cross-row cells, got #{reset_count}"
+    end
+
+    test "reset emitted only when attributes are removed", %{state: state} do
+      cells = [
+        {{3, 1}, {"A", :default, :default, [:bold, :italic]}},
+        {{3, 2}, {"B", :default, :default, [:bold]}}
+      ]
+
+      output =
+        capture_io(fn ->
+          {:ok, _state} = Raw.draw_cells(state, cells)
+        end)
+
+      # Should emit exactly one reset (when italic is removed)
+      reset_count = length(Regex.scan(~r/\e\[0m/, output))
+      assert reset_count == 1
+    end
+
+    test "unsorted cells are sorted before coalescing", %{state: state} do
+      # Pass cells in reverse order on row 3 (not at cursor start)
+      cells = [
+        {{3, 3}, {"C", :default, :default, []}},
+        {{3, 1}, {"A", :default, :default, []}},
+        {{3, 2}, {"B", :default, :default, []}}
+      ]
+
+      output =
+        capture_io(fn ->
+          {:ok, _state} = Raw.draw_cells(state, cells)
+        end)
+
+      # Should coalesce into single run after sorting
+      cursor_positions = Regex.scan(~r/\e\[\d+;\d+H/, output)
+      assert length(cursor_positions) == 1
+      assert output =~ "ABC"
+    end
+
+    test "mixed rows with runs produce correct output structure", %{state: state} do
+      cells = [
+        # Row 2: two runs (not at cursor start {1,1})
+        {{2, 1}, {"A", :red, :default, []}},
+        {{2, 2}, {"B", :red, :default, []}},
+        {{2, 10}, {"C", :blue, :default, []}},
+        # Row 4: one run (skip row 3)
+        {{4, 5}, {"D", :green, :default, []}},
+        {{4, 6}, {"E", :green, :default, []}},
+        {{4, 7}, {"F", :green, :default, []}}
+      ]
+
+      output =
+        capture_io(fn ->
+          {:ok, result} = Raw.draw_cells(state, cells)
+          # Final cursor at end of last cell
+          assert result.cursor_position == {4, 8}
+        end)
+
+      # 3 runs = 3 cursor positions
+      cursor_positions = Regex.scan(~r/\e\[\d+;\d+H/, output)
+      assert length(cursor_positions) == 3
+
+      # Verify character groupings
+      assert output =~ "AB"
+      assert output =~ "DEF"
+    end
+
+    test "full screen render is efficient", %{state: state} do
+      # 24 rows x 80 cols, all same style
+      cells =
+        for row <- 1..24, col <- 1..80 do
+          {{row, col}, {"X", :default, :default, []}}
+        end
+
+      output =
+        capture_io(fn ->
+          {:ok, result} = Raw.draw_cells(state, cells)
+          assert result.cursor_position == {24, 81}
+        end)
+
+      # Row 1 starts at cursor {1,1} so no move needed: 23 explicit positions
+      cursor_positions = Regex.scan(~r/\e\[\d+;\d+H/, output)
+      assert length(cursor_positions) == 23
+
+      # Output should contain 24 runs of 80 X's
+      x_runs = Regex.scan(~r/X{80}/, output)
+      assert length(x_runs) == 24
+
+      # Total output should be much less than per-cell approach
+      # Per-cell: ~10 bytes cursor * 1920 + 1920 chars = ~21,000 bytes
+      # Coalesced: ~8 bytes cursor * 23 + 1920 chars + style = ~2,200 bytes
+      assert byte_size(output) < 5000,
+             "Full screen output #{byte_size(output)} bytes, expected < 5000"
+    end
+  end
+
+  # ===========================================================================
   # Section: Security Limits Tests
   # ===========================================================================
 


### PR DESCRIPTION
## Summary

- Implement run coalescing in the raw backend to detect contiguous cell sequences, minimizing cursor movement and style escape sequences
- Refactor buffer diffing from O(n²) `Enum.at` approach to a single O(n) zip-based pass, eliminating a major bottleneck for high-resolution screens
- Simplify terminal initialization/cleanup by removing redundant alternate screen and cursor visibility calls already managed by the Terminal GenServer

## Test plan

- [x] Verify coalesced runs correctly handle sorting, style continuity, and efficient byte output
- [ ] Run full test suite (`mix test`)
- [ ] Manual verification with dashboard and other examples