### PR TITLE
Handle Shift+Tab CSI variants in EscapeParser

### DIFF
--- a/lib/term_ui/terminal/escape_parser.ex
+++ b/lib/term_ui/terminal/escape_parser.ex
@@ -179,6 +179,9 @@ defmodule TermUI.Terminal.EscapeParser do
   defp parse_csi_sequence(<<"C", rest::binary>>), do: {:ok, Event.key(:right), rest}
   defp parse_csi_sequence(<<"D", rest::binary>>), do: {:ok, Event.key(:left), rest}
 
+  defp parse_csi_sequence(<<"Z", rest::binary>>),
+    do: {:ok, Event.key(:tab, modifiers: [:shift]), rest}
+
   # Home/End
   defp parse_csi_sequence(<<"H", rest::binary>>), do: {:ok, Event.key(:home), rest}
   defp parse_csi_sequence(<<"F", rest::binary>>), do: {:ok, Event.key(:end), rest}
@@ -220,6 +223,13 @@ defmodule TermUI.Terminal.EscapeParser do
 
     modifiers = decode_modifier(modifier - ?0)
     event = Event.key(key, modifiers: modifiers)
+    {:ok, event, rest}
+  end
+
+  # Modified Shift+Tab sequence: ESC [ 1 ; modifier Z
+  defp parse_csi_sequence(<<"1;", modifier, "Z", rest::binary>>) when modifier in ?0..?9 do
+    modifiers = decode_modifier(modifier - ?0)
+    event = Event.key(:tab, modifiers: modifiers)
     {:ok, event, rest}
   end
 

--- a/test/term_ui/terminal/escape_parser_test.exs
+++ b/test/term_ui/terminal/escape_parser_test.exs
@@ -230,6 +230,22 @@ defmodule TermUI.Terminal.EscapeParserTest do
   end
 
   describe "parse/1 - modified arrow keys" do
+    test "parses Shift+Tab (ESC[Z)" do
+      {events, remaining} = EscapeParser.parse("\e[Z")
+      assert remaining == <<>>
+      assert [%Event.Key{key: :tab, modifiers: modifiers}] = events
+      assert :shift in modifiers
+    end
+
+    test "parses Shift+Tab variant (ESC[1;2Z)" do
+      {events, remaining} = EscapeParser.parse("\e[1;2Z")
+      assert remaining == <<>>
+      assert [%Event.Key{key: :tab, modifiers: modifiers}] = events
+      assert :shift in modifiers
+      refute :alt in modifiers
+      refute :ctrl in modifiers
+    end
+
     test "parses Shift+Up (ESC[1;2A)" do
       {events, remaining} = EscapeParser.parse("\e[1;2A")
       assert remaining == <<>>


### PR DESCRIPTION
## Summary
Adds Shift+Tab support for CSI variants in `EscapeParser`.

## Why
Different terminals emit different CSI sequences for reverse tab. We already handle many modifier variants for arrows, but reverse-tab was missing and navigation behavior was inconsistent.

## What changed
- Added parsing for `ESC [ Z`.
- Added parsing for modified variant `ESC [ 1 ; <modifier> Z` (including `ESC[1;2Z` for Shift+Tab).
- Added parser tests covering both forms.

## Validation
- `mix test test/term_ui/terminal/escape_parser_test.exs`
