### PR TITLE
Support root startup commands and table refresh

### DIFF
--- a/lib/term_ui/command.ex
+++ b/lib/term_ui/command.ex
@@ -59,8 +59,8 @@ defmodule TermUI.Command do
       Command.timer(1000, :timer_done)
       Command.timer(500, {:tick, 1})
   """
-  @spec timer(pos_integer(), term()) :: t()
-  def timer(delay_ms, on_result) when is_integer(delay_ms) and delay_ms > 0 do
+  @spec timer(non_neg_integer(), term()) :: t()
+  def timer(delay_ms, on_result) when is_integer(delay_ms) and delay_ms >= 0 do
     %__MODULE__{
       type: :timer,
       payload: delay_ms,
@@ -194,7 +194,7 @@ defmodule TermUI.Command do
   @spec validate(t()) :: :ok | {:error, term()}
   def validate(%__MODULE__{type: :none}), do: :ok
 
-  def validate(%__MODULE__{type: :timer, payload: delay}) when is_integer(delay) and delay > 0,
+  def validate(%__MODULE__{type: :timer, payload: delay}) when is_integer(delay) and delay >= 0,
     do: :ok
 
   def validate(%__MODULE__{type: :interval, payload: interval})

--- a/lib/term_ui/elm.ex
+++ b/lib/term_ui/elm.ex
@@ -41,6 +41,11 @@ defmodule TermUI.Elm do
   @type msg :: Message.t()
   @type command :: term()
   @type render_tree :: term()
+  @type init_result ::
+          state()
+          | {state(), [command()]}
+          | {:ok, state()}
+          | {:ok, state(), [command()]}
 
   @type update_result ::
           {state(), [command()]}
@@ -143,7 +148,7 @@ defmodule TermUI.Elm do
 
   Initial state for the component.
   """
-  @callback init(opts :: keyword()) :: state()
+  @callback init(opts :: keyword()) :: init_result()
 
   @optional_callbacks [init: 1]
 
@@ -170,6 +175,24 @@ defmodule TermUI.Elm do
       defoverridable init: 1, event_to_msg: 2
     end
   end
+
+  @doc """
+  Normalizes init result to standard form.
+
+  Supports plain state as well as state with startup commands.
+  """
+  @spec normalize_init_result(init_result()) :: {state(), [command()]}
+  def normalize_init_result({:ok, state}), do: {state, []}
+
+  def normalize_init_result({:ok, state, commands}) when is_list(commands) do
+    {state, commands}
+  end
+
+  def normalize_init_result({state, commands}) when is_list(commands) do
+    {state, commands}
+  end
+
+  def normalize_init_result(state), do: {state, []}
 
   @doc """
   Normalizes update result to standard form.

--- a/lib/term_ui/runtime.ex
+++ b/lib/term_ui/runtime.ex
@@ -27,6 +27,8 @@ defmodule TermUI.Runtime do
   require Logger
 
   alias TermUI.Backend.Selector
+  alias TermUI.Command
+  alias TermUI.Command.Executor
   alias TermUI.Config
   alias TermUI.Elm
   alias TermUI.Event
@@ -318,8 +320,14 @@ defmodule TermUI.Runtime do
     # Store backend info in persistent_term for global access
     PersistentTerms.store_backend_context(backend_mode, capabilities)
 
-    # Initialize root component state
-    root_state = root_module.init(opts)
+    # Initialize async command execution before the root module boots.
+    {:ok, command_executor} = Executor.start_link()
+
+    # Initialize root component state and any startup commands.
+    {root_state, init_commands} =
+      opts
+      |> root_module.init()
+      |> Elm.normalize_init_result()
 
     # Initialize input handling
     {use_input_handler, input_handler, input_state, input_reader} =
@@ -341,6 +349,7 @@ defmodule TermUI.Runtime do
         backend: backend,
         backend_state: backend_state,
         capabilities: capabilities,
+        command_executor: command_executor,
         input_handler: input_handler,
         input_state: input_state,
         logger_handler_config: logger_handler_config
@@ -359,6 +368,11 @@ defmodule TermUI.Runtime do
       else
         state
       end
+
+    state =
+      init_commands
+      |> Enum.map(&{:root, &1})
+      |> then(&execute_commands(&1, state))
 
     {:ok, state}
   end
@@ -433,6 +447,7 @@ defmodule TermUI.Runtime do
       backend: params.backend,
       backend_state: params.backend_state,
       capabilities: params.capabilities,
+      command_executor: params.command_executor,
       input_handler: params.input_handler,
       input_state: params.input_state,
       logger_handler_config: params[:logger_handler_config]
@@ -679,6 +694,12 @@ defmodule TermUI.Runtime do
   @impl true
   def handle_info({:DOWN, _ref, :process, _pid, _reason}, state) do
     # Command task completed (handled via command_result)
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info({:command_result, component_id, command_id, result}, state) do
+    state = handle_command_result(component_id, command_id, result, state)
     {:noreply, state}
   end
 
@@ -1091,15 +1112,43 @@ defmodule TermUI.Runtime do
       GenServer.cast(self(), :shutdown)
       %{state | shutting_down: true}
     else
-      # Track pending commands for execution
-      pending =
-        Enum.reduce(commands, state.pending_commands, fn {component_id, cmd}, acc ->
-          command_id = make_ref()
-          Map.put(acc, command_id, %{component_id: component_id, command: cmd})
-        end)
-
-      %{state | pending_commands: pending}
+      Enum.reduce(commands, state, fn {component_id, cmd}, acc ->
+        execute_command(component_id, cmd, acc)
+      end)
     end
+  end
+
+  defp execute_command(_component_id, %Command{type: :none}, state), do: state
+
+  defp execute_command(component_id, %Command{} = command, state) do
+    case Executor.execute(state.command_executor, command, self(), component_id) do
+      {:ok, command_id} ->
+        pending =
+          Map.put(state.pending_commands, command_id, %{
+            component_id: component_id,
+            command: command
+          })
+
+        %{state | pending_commands: pending}
+
+      {:error, reason} ->
+        enqueue_message(component_id, {:error, reason}, state)
+    end
+  end
+
+  defp execute_command(component_id, {:timer, ms, message}, state)
+       when is_integer(ms) and ms >= 0 do
+    execute_command(component_id, Command.timer(ms, message), state)
+  end
+
+  defp execute_command(_component_id, {:send, pid, message}, state) when is_pid(pid) do
+    send(pid, message)
+    state
+  end
+
+  defp execute_command(component_id, other, state) do
+    Logger.warning("Unknown command for #{inspect(component_id)}: #{inspect(other)}")
+    state
   end
 
   defp handle_command_result(component_id, command_id, result, state) do
@@ -1107,8 +1156,17 @@ defmodule TermUI.Runtime do
     pending = Map.delete(state.pending_commands, command_id)
     state = %{state | pending_commands: pending}
 
-    # Send result as message to component
-    enqueue_message(component_id, result, state)
+    if state.shutting_down do
+      state
+    else
+      case result do
+        {:send_to, target_component, message} ->
+          enqueue_message(target_component, message, state)
+
+        _ ->
+          enqueue_message(component_id, result, state)
+      end
+    end
   end
 
   # --- Rendering ---
@@ -1440,8 +1498,12 @@ defmodule TermUI.Runtime do
   end
 
   defp do_shutdown(state) do
-    # Wait for pending commands to complete (with timeout)
-    # For now, just clear them
+    if state.command_executor do
+      Enum.each(Map.keys(state.pending_commands), fn command_id ->
+        _ = Executor.cancel(state.command_executor, command_id)
+      end)
+    end
+
     state = %{state | pending_commands: %{}}
 
     # Terminate components (leaf to root)

--- a/lib/term_ui/runtime/state.ex
+++ b/lib/term_ui/runtime/state.ex
@@ -12,8 +12,10 @@ defmodule TermUI.Runtime.State do
   - Shutdown status
   - Backend selection and capabilities
   - Input handler (Raw or TTY mode)
+  - Command executor for async side effects
   """
 
+  alias TermUI.Command.Executor
   alias TermUI.EventQueue
   alias TermUI.MessageQueue
 
@@ -47,6 +49,7 @@ defmodule TermUI.Runtime.State do
           backend: module() | nil,
           backend_state: term() | nil,
           capabilities: capabilities() | nil,
+          command_executor: Executor.t() | nil,
           input_handler: module() | nil,
           input_state: term() | nil,
           logger_handler_config: map() | nil
@@ -82,6 +85,7 @@ defmodule TermUI.Runtime.State do
     backend: nil,
     backend_state: nil,
     capabilities: nil,
+    command_executor: nil,
     input_handler: nil,
     input_state: nil,
     logger_handler_config: nil

--- a/lib/term_ui/widgets/table.ex
+++ b/lib/term_ui/widgets/table.ex
@@ -122,10 +122,15 @@ defmodule TermUI.Widgets.Table do
     state =
       state
       |> Map.put(:columns, new_props.columns)
-      |> Map.put(:data, new_props.data)
-
-    # Re-sort if data changed
-    state = apply_sort(state)
+      |> Map.put(:selection_mode, Map.get(new_props, :selection_mode, state.selection_mode))
+      |> Map.put(:sortable, Map.get(new_props, :sortable, state.sortable))
+      |> Map.put(:on_select, Map.get(new_props, :on_select, state.on_select))
+      |> Map.put(:on_sort, Map.get(new_props, :on_sort, state.on_sort))
+      |> Map.put(:header_style, Map.get(new_props, :header_style, state.header_style))
+      |> Map.put(:row_style, Map.get(new_props, :row_style, state.row_style))
+      |> Map.put(:selected_style, Map.get(new_props, :selected_style, state.selected_style))
+      |> Map.put(:alternating, Map.get(new_props, :alternating, state.alternating))
+      |> set_data(new_props.data)
 
     {:ok, state}
   end
@@ -480,6 +485,32 @@ defmodule TermUI.Widgets.Table do
   end
 
   @doc """
+  Replaces the table data and preserves table state as much as possible.
+
+  The cursor, selection, and scroll offset are clamped to the new row count,
+  and the current sort is re-applied.
+  """
+  @spec set_data(map(), [map()]) :: map()
+  def set_data(state, data) when is_list(data) do
+    max_index = max(0, length(data) - 1)
+
+    selected =
+      state.selected
+      |> Enum.filter(&(&1 <= max_index))
+      |> MapSet.new()
+
+    state =
+      state
+      |> Map.put(:data, data)
+      |> Map.put(:cursor, min(state.cursor, max_index))
+      |> Map.put(:selected, selected)
+      |> apply_sort()
+
+    max_offset = max(0, length(state.sorted_data) - state.visible_height)
+    %{state | scroll_offset: min(state.scroll_offset, max_offset)}
+  end
+
+  @doc """
   Gets the current selection.
 
   ## Returns
@@ -489,6 +520,14 @@ defmodule TermUI.Widgets.Table do
   @spec get_selection(map()) :: [map()]
   def get_selection(state) do
     get_selected_rows(state)
+  end
+
+  @doc """
+  Backwards-compatible alias for `get_selection/1`.
+  """
+  @spec get_selected(map()) :: [map()]
+  def get_selected(state) do
+    get_selection(state)
   end
 
   @doc """

--- a/test/term_ui/app_test.exs
+++ b/test/term_ui/app_test.exs
@@ -2,6 +2,7 @@ defmodule TermUI.AppTest do
   use ExUnit.Case, async: false
 
   alias TermUI.App
+  alias TermUI.Command
 
   # Clean up persistent_term values between tests
   setup do
@@ -36,6 +37,41 @@ defmodule TermUI.AppTest do
     def event_to_msg(_, _), do: :ignore
     def update(_, state), do: {state, []}
     def view(state), do: {:text, "Count: " <> to_string(state.count)}
+  end
+
+  defmodule InitCommandCounter do
+    use TermUI.Elm
+
+    def init(_opts) do
+      {:ok, %{ticks: 0}, [Command.timer(0, :tick)]}
+    end
+
+    def event_to_msg(_, _), do: :ignore
+
+    def update(:tick, state), do: {%{state | ticks: state.ticks + 1}, []}
+    def update(_, state), do: {state, []}
+    def view(_state), do: {:text, "Init command"}
+  end
+
+  defmodule RuntimeCommandCounter do
+    use TermUI.Elm
+
+    def init(_opts), do: %{ticks: 0, pongs: 0}
+
+    def event_to_msg(_, _), do: :ignore
+
+    def update(:start_timer, state) do
+      {state, [Command.timer(0, :tick)]}
+    end
+
+    def update(:start_send_after, state) do
+      {state, [Command.send_after(:root, :pong, 1)]}
+    end
+
+    def update(:tick, state), do: {%{state | ticks: state.ticks + 1}, []}
+    def update(:pong, state), do: {%{state | pongs: state.pongs + 1}, []}
+    def update(_, state), do: {state, []}
+    def view(_state), do: {:text, "Runtime commands"}
   end
 
   describe "start/2" do
@@ -213,6 +249,46 @@ defmodule TermUI.AppTest do
         end)
 
       assert {:ok, :exited_normally} = Task.await(task, 5000)
+    end
+  end
+
+  describe "root command execution" do
+    test "runs startup commands returned from init/1" do
+      {:ok, pid} = App.start(InitCommandCounter, skip_terminal: true)
+
+      Process.sleep(25)
+      :ok = TermUI.Runtime.sync(pid)
+
+      state = TermUI.Runtime.get_state(pid)
+      assert state.root_state.ticks == 1
+
+      GenServer.stop(pid)
+    end
+
+    test "executes runtime commands returned from update/2" do
+      {:ok, pid} = App.start(RuntimeCommandCounter, skip_terminal: true)
+
+      TermUI.Runtime.send_message(pid, :root, :start_timer)
+      Process.sleep(25)
+      :ok = TermUI.Runtime.sync(pid)
+
+      state = TermUI.Runtime.get_state(pid)
+      assert state.root_state.ticks == 1
+
+      GenServer.stop(pid)
+    end
+
+    test "routes send_after results to the target component message queue" do
+      {:ok, pid} = App.start(RuntimeCommandCounter, skip_terminal: true)
+
+      TermUI.Runtime.send_message(pid, :root, :start_send_after)
+      Process.sleep(25)
+      :ok = TermUI.Runtime.sync(pid)
+
+      state = TermUI.Runtime.get_state(pid)
+      assert state.root_state.pongs == 1
+
+      GenServer.stop(pid)
     end
   end
 

--- a/test/term_ui/command_test.exs
+++ b/test/term_ui/command_test.exs
@@ -13,6 +13,14 @@ defmodule TermUI.CommandTest do
       assert cmd.timeout == :infinity
     end
 
+    test "accepts zero-delay timers for immediate scheduling" do
+      cmd = Command.timer(0, :timer_done)
+
+      assert cmd.type == :timer
+      assert cmd.payload == 0
+      assert cmd.on_result == :timer_done
+    end
+
     test "accepts tuple as result message" do
       cmd = Command.timer(500, {:tick, 1})
 
@@ -71,6 +79,10 @@ defmodule TermUI.CommandTest do
   describe "validate/1" do
     test "validates timer command" do
       assert :ok = Command.validate(Command.timer(100, :done))
+    end
+
+    test "validates zero-delay timer command" do
+      assert :ok = Command.validate(Command.timer(0, :done))
     end
 
     test "validates interval command" do

--- a/test/term_ui/widgets/table_test.exs
+++ b/test/term_ui/widgets/table_test.exs
@@ -455,4 +455,39 @@ defmodule TermUI.Widgets.TableTest do
       assert hd(new_state.sorted_data).name == "Zoe"
     end
   end
+
+  describe "data helpers" do
+    test "set_data updates rows and clamps cursor state" do
+      props = Table.new(columns: @test_columns, data: @test_data)
+      {:ok, state} = Table.init(props)
+
+      state =
+        state
+        |> Map.put(:cursor, 4)
+        |> Map.put(:scroll_offset, 4)
+        |> Map.put(:selected, MapSet.new([1, 4]))
+        |> Table.sort_by(:age, :asc)
+
+      new_data = [
+        %{name: "Zoe", age: 18, city: "Miami"},
+        %{name: "Yuki", age: 40, city: "Tokyo"}
+      ]
+
+      state = Table.set_data(state, new_data)
+
+      assert state.data == new_data
+      assert state.cursor == 1
+      assert state.scroll_offset == 0
+      assert state.selected == MapSet.new([1])
+      assert Enum.map(state.sorted_data, & &1.name) == ["Zoe", "Yuki"]
+    end
+
+    test "get_selected is an alias for get_selection" do
+      props = Table.new(columns: @test_columns, data: @test_data)
+      {:ok, state} = Table.init(props)
+      state = %{state | selected: MapSet.new([0, 2])}
+
+      assert Table.get_selected(state) == Table.get_selection(state)
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- execute root Elm commands through the runtime and support startup commands from `init/1`
- allow zero-delay timers and route `send_after` results back to the target component
- add `Table.set_data/2` and `get_selected/1`, and clamp cursor/selection when table data changes

## Testing
- ASDF_ELIXIR_VERSION=1.19.5-otp-28 ASDF_ERLANG_VERSION=28.3.1 mix test test/term_ui/command_test.exs test/term_ui/app_test.exs test/term_ui/widgets/table_test.exs