### PR TITLE
Fix diff renderer dropping repeated style after `:reset` op

### DIFF
--- a/lib/term_ui/renderer/diff.ex
+++ b/lib/term_ui/renderer/diff.ex
@@ -304,6 +304,15 @@ defmodule TermUI.Renderer.Diff do
     end
   end
 
+  # A :reset op writes "\e[0m" to the terminal, clearing all SGR state.
+  # We must forget the tracked last_style so that the next :style op is
+  # re-emitted even if it matches what was active before the reset --
+  # otherwise multi-row spans that share a style lose their styling on
+  # every row but the first.
+  defp filter_redundant_style(:reset, {acc, _last_style}) do
+    {[:reset | acc], nil}
+  end
+
   defp filter_redundant_style(op, {acc, last_style}) do
     {[op | acc], last_style}
   end

--- a/test/term_ui/renderer/diff_test.exs
+++ b/test/term_ui/renderer/diff_test.exs
@@ -531,6 +531,37 @@ defmodule TermUI.Renderer.DiffTest do
       Buffer.destroy(previous)
     end
 
+    test "re-emits style on each row when adjacent rows share a style" do
+      # Regression test: filter_redundant_style must invalidate its
+      # tracked last_style when a :reset op flows through, otherwise
+      # the second row span's :style gets deduped after the :reset
+      # has already cleared the terminal SGR state -- leaving every
+      # row but the first rendered without styling.
+      {:ok, current} = Buffer.new(2, 5)
+      {:ok, previous} = Buffer.new(2, 5)
+
+      cell = Cell.new("X", bg: 236)
+
+      for col <- 1..5 do
+        Buffer.set_cell(current, 1, col, cell)
+        Buffer.set_cell(current, 2, col, cell)
+      end
+
+      operations = Diff.diff(current, previous)
+
+      style_ops =
+        Enum.filter(operations, fn
+          {:style, %Style{bg: 236}} -> true
+          _ -> false
+        end)
+
+      assert length(style_ops) == 2,
+             "expected one :style op per row, got #{length(style_ops)}: #{inspect(operations)}"
+
+      Buffer.destroy(current)
+      Buffer.destroy(previous)
+    end
+
     test "handles changes at buffer boundaries" do
       {:ok, current} = Buffer.new(5, 10)
       {:ok, previous} = Buffer.new(5, 10)


### PR DESCRIPTION
`filter_redundant_style` tracks `last_style` so it can dedupe `:style` ops that match the previous one. But it ignored `:reset` ops, which write `\e[0m` to the terminal and clear all SGR state. When two adjacent row spans share a style, the sequence was:

  1. row N: `:reset`, `:move`, `:style(X)`, `:text(...)` -- updates `last_style` to X
  2. row N+1: `:reset`, `:move`, `:style(X)`, `:text(...)` -- `:reset` wipes terminal SGR state -- `:style(X)` matches last_style and is deduped away

So row N+1 emitted only text, leaving its cells rendered without any styling. Symptom: multi-row styled spans (e.g. a coloured-band "user message" panel, or a styled status bar that shares a style with a preceding indicator) render styled on the first row and bare on every row after.

Fix: add a clause to `filter_redundant_style` for `:reset` that clears the tracked `last_style`, forcing the next `:style` op to be emitted in full. Regression test included.