### PR TITLE
Parse bracketed-paste sequences into Paste events

### DIFF
--- a/lib/term_ui/terminal/escape_parser.ex
+++ b/lib/term_ui/terminal/escape_parser.ex
@@ -30,6 +30,11 @@ defmodule TermUI.Terminal.EscapeParser do
   # Provides defense against malicious input with huge coordinates.
   @max_mouse_coordinate 9999
 
+  # Maximum bytes to buffer for an unterminated bracketed-paste sequence.
+  # Generous enough that real pastes never trip it; prevents unbounded memory
+  # growth from a stuck terminal that emits ESC[200~ but never the end marker.
+  @max_paste_buffer 8 * 1024 * 1024
+
   @doc """
   Parses input bytes into a list of events and remaining bytes.
 
@@ -193,6 +198,30 @@ defmodule TermUI.Terminal.EscapeParser do
   defp parse_csi_sequence(<<"4~", rest::binary>>), do: {:ok, Event.key(:end), rest}
   defp parse_csi_sequence(<<"5~", rest::binary>>), do: {:ok, Event.key(:page_up), rest}
   defp parse_csi_sequence(<<"6~", rest::binary>>), do: {:ok, Event.key(:page_down), rest}
+
+  # Bracketed paste: ESC [ 200 ~ content ESC [ 201 ~
+  # Scan forward for the end marker and emit the parked content as a single
+  # Paste event. Without the end marker, return :incomplete so InputReader
+  # keeps buffering — up to @max_paste_buffer, after which we bail out and
+  # emit whatever we have so the buffer cannot grow without bound. An
+  # eventually arriving \e[201~ is then swallowed by the stray-end clause.
+  defp parse_csi_sequence(<<"200~", rest::binary>>) do
+    case :binary.match(rest, <<@escape, "[201~">>) do
+      {pos, _len} ->
+        content = binary_part(rest, 0, pos)
+        tail = binary_part(rest, pos + 6, byte_size(rest) - pos - 6)
+        {:ok, Event.paste(content), tail}
+
+      :nomatch when byte_size(rest) > @max_paste_buffer ->
+        {:ok, Event.paste(rest), <<>>}
+
+      :nomatch ->
+        :incomplete
+    end
+  end
+
+  # Stray paste-end marker (defensive): consume silently.
+  defp parse_csi_sequence(<<"201~", rest::binary>>), do: {:ok, Event.key(:unknown), rest}
 
   # Function keys F1-F4 (some terminals)
   defp parse_csi_sequence(<<"11~", rest::binary>>), do: {:ok, Event.key(:f1), rest}
@@ -408,6 +437,7 @@ defmodule TermUI.Terminal.EscapeParser do
   @spec partial_sequence?(binary()) :: boolean()
   def partial_sequence?(<<@escape>>), do: true
   def partial_sequence?(<<@escape, "[">>), do: true
+  def partial_sequence?(<<@escape, "[200~", _rest::binary>>), do: true
   def partial_sequence?(<<@escape, "[", rest::binary>>), do: partial_csi?(rest)
   def partial_sequence?(<<@escape, "O">>), do: true
   def partial_sequence?(_), do: false

--- a/test/term_ui/terminal/escape_parser_test.exs
+++ b/test/term_ui/terminal/escape_parser_test.exs
@@ -367,5 +367,52 @@ defmodule TermUI.Terminal.EscapeParserTest do
     test "returns false for empty input" do
       assert EscapeParser.partial_sequence?("") == false
     end
+
+    test "returns true for in-flight bracketed paste" do
+      assert EscapeParser.partial_sequence?("\e[200~partial content not yet ended") == true
+    end
+  end
+
+  describe "parse/1 - bracketed paste" do
+    test "parses a complete bracketed-paste sequence into a Paste event" do
+      input = "\e[200~hello\nworld\e[201~"
+      {events, remaining} = EscapeParser.parse(input)
+
+      assert [%TermUI.Event.Paste{content: "hello\nworld"}] = events
+      assert remaining == ""
+    end
+
+    test "preserves bytes after the paste end marker" do
+      input = "\e[200~abc\e[201~xyz"
+      {events, remaining} = EscapeParser.parse(input)
+
+      assert [%TermUI.Event.Paste{content: "abc"}, %TermUI.Event.Key{key: "x"} | _] = events
+      assert remaining == ""
+    end
+
+    test "incomplete paste (no end marker) is buffered" do
+      input = "\e[200~not finished yet"
+      {events, remaining} = EscapeParser.parse(input)
+
+      assert events == []
+      assert remaining == input
+    end
+
+    test "preserves embedded escape sequences inside paste body" do
+      input = "\e[200~line1\nline2\nline3\e[201~"
+      {events, _remaining} = EscapeParser.parse(input)
+
+      assert [%TermUI.Event.Paste{content: "line1\nline2\nline3"}] = events
+    end
+
+    test "bails out with a Paste event when an unterminated paste exceeds the buffer cap" do
+      # Just over 8 MiB of body, no \e[201~ end marker.
+      oversized = :binary.copy("x", 8 * 1024 * 1024 + 1)
+      input = "\e[200~" <> oversized
+      {events, remaining} = EscapeParser.parse(input)
+
+      assert [%TermUI.Event.Paste{content: ^oversized}] = events
+      assert remaining == ""
+    end
   end
 end


### PR DESCRIPTION
I ran into this gap while implementing an input box where I want to enable the user to paste multiline text without indadvertedly submitting.

The InputReader-backed `EscapeParser` had no clause for `ESC[200~/ESC[201~`, so when bracketed paste mode is enabled the markers leaked into the byte stream as printable text and the pasted content was emitted as a flurry of key events (including embedded \r being interpreted as Enter).

With this change we recognise `ESC[200~content ESC[201~` as a single Paste event. If the end marker isn't in the current chunk, return `:incomplete` and signal `partial_sequence?/1` so InputReader keeps buffering.

We cap that buffering at 8 MiB so a stuck terminal that opens a paste but never closes it cannot grow the input buffer without bound; on overflow we emit what we have as a `Paste` event and the eventual stray `\e[201~` is consumed by the existing defensive end-marker clause.