### PR TITLE
Document TermUI 1.0 platform verification waivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,9 @@ rendering, constraint-based layouts, and the complete widget set.
 - Native Windows console support is experimental. TermUI 1.0 does not configure
   Win32 console modes or implement native raw input and resize handling; use WSL
   where practical and validate the chosen terminal environment.
+- Mouse tracking is disabled under WSL/ConPTY because the required disable
+  sequences are not handled reliably; keyboard, resize, paste, and cleanup
+  remain supported through the Unix backend.
 - OTP 26 TTY applications can query terminal dimensions, but its signal API
   does not provide automatic `SIGWINCH` resize notifications.
 - A resume or external terminal redraw may require `TermUI.Runtime.force_render/1`.

--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ OTP SSH channel devices.
 Native Windows console support is experimental. ANSI output can work in a
 terminal where virtual-terminal processing is already enabled, but TermUI does
 not yet configure Win32 console modes or provide native raw input and resize
-handling. On Windows, prefer WSL and verify keyboard, mouse, resize, and cleanup
-behavior for the terminal you deploy with.
+handling. On Windows, prefer WSL and verify keyboard, resize, paste, and cleanup
+behavior for the terminal you deploy with. Mouse tracking is intentionally
+disabled under WSL/ConPTY because disabling sequences are not handled reliably.
 
 OTP 26's signal API does not expose `SIGWINCH` to application handlers. The
 minimum-version TTY backend still supports size queries, but automatic local

--- a/guides/user/08-terminal.md
+++ b/guides/user/08-terminal.md
@@ -253,7 +253,7 @@ depend on the terminal emulator:
 | GNOME Terminal | Linux | Full support |
 | Terminal.app | macOS | Limited mouse |
 | xterm | Unix | Full support |
-| Windows Terminal with WSL | Windows/WSL | Unix backend; verify input and cleanup for the deployed environment |
+| Windows Terminal with WSL | Windows/WSL | Unix backend; mouse tracking disabled; verify input, resize, paste, and cleanup |
 | Windows Terminal native | Windows | Experimental; native raw console mode and resize handling are not implemented |
 
 Native Windows may render ANSI output when virtual-terminal processing is

--- a/release-1.0.0.md
+++ b/release-1.0.0.md
@@ -90,10 +90,23 @@ families, so required checks can be satisfied on release-branch pull requests.
 The following gates still require maintainer or platform access and are not
 represented as complete by the local work:
 
-- A live SSH client/server session, interactive macOS terminal behavior,
-  WSL/ConPTY, and applicable native Windows behavior need the manual terminal
-  sign-off listed below. Hosted CI is non-interactive and does not substitute
-  for those checks.
+- Live SSH client/server verification was waived for `1.0.0` on 2026-08-27
+  because no representative host system is available. This is an accepted
+  release risk, not a successful test; reproducible backend lifecycle coverage
+  remains green.
+- Interactive macOS terminal verification was waived for `1.0.0` on
+  2026-08-27 because no macOS system is available. This is an accepted release
+  risk, not a successful manual test; the complete hosted macOS suite remains
+  green.
+- Interactive WSL/ConPTY verification was waived for `1.0.0` on 2026-08-28
+  because no representative system is available. This is an accepted release
+  risk, not a successful manual test; the relevant automated suite remains
+  green.
+- Interactive native Windows verification was waived for `1.0.0` on
+  2026-08-28 because no representative system is available. This is an
+  accepted release risk, not a successful manual test. Native console mode,
+  raw input, and resize remain explicitly unsupported in `1.0.0`; the hosted
+  Windows suite remains green.
 - Hex authentication is required to complete `mix hex.publish --dry-run`; the
   unauthenticated command rebuilt version `1.0.0`, displayed the intended
   package contents, and stopped at authentication without publishing.
@@ -240,10 +253,33 @@ Terminal verification status:
 - [x] Normal exit, application error, and interrupted-session cleanup.
 - [x] Reproducible SSH backend input, resize, disconnect, and cleanup
       integration coverage.
-- [ ] Live SSH client/server terminal behavior.
-- [ ] macOS behavior.
-- [ ] WSL/ConPTY behavior.
-- [ ] Windows behavior where supported.
+- [ ] Live SSH client/server terminal behavior — waived for `1.0.0` on
+      2026-08-27 because no representative host system is available; not
+      verified.
+- [ ] macOS behavior — waived for `1.0.0` on 2026-08-27 because no interactive
+      macOS system is available; hosted CI passes, but manual behavior was not
+      verified. The deferred procedure remains in
+      [`test/manual/mac.md`](test/manual/mac.md).
+- [ ] WSL/ConPTY behavior — waived for `1.0.0` on 2026-08-28 because no
+      representative system is available; not manually verified. The deferred
+      procedure remains in [`test/manual/wsl.md`](test/manual/wsl.md).
+- [ ] Windows behavior where supported — waived for `1.0.0` on 2026-08-28
+      because no representative system is available; not manually verified.
+      Native console behavior remains unsupported. The deferred procedure
+      remains in [`test/manual/windows.md`](test/manual/windows.md).
+
+Deferred verification after `1.0.0`:
+
+- [ ] Exercise the SSH backend through a live client/server channel.
+- [ ] Complete the interactive macOS checklist.
+- [ ] Complete the WSL/ConPTY checklist in Windows Terminal.
+- [ ] Complete the native Windows checklist after the unsupported console-mode,
+      raw-input, and resize gaps are implemented.
+
+The waivers apply only to the `1.0.0` release decision. Keep these items open
+until representative systems are available, record their results in the
+corresponding manual checklists, and do not use the waivers as evidence of
+platform support in a later release.
 
 Document any platform limitations in the README and release notes.
 
@@ -403,7 +439,8 @@ Release gate:
 - [x] Documentation builds without warnings.
 - [x] Dependency vulnerability, lockfile, and Hex retirement audits pass.
 - [x] Every supported example compiles.
-- [ ] Manual terminal verification passes.
+- [x] Linux manual terminal verification passes; approved platform waivers are
+      recorded for unavailable environments.
 - [ ] `mix hex.publish --dry-run` passes.
 - [x] The unpacked package contains exactly the intended release files.
 
@@ -428,7 +465,7 @@ Require the following before merging:
 - [x] Green required CI checks.
 - [ ] Successful Hex dry run.
 - [x] Successful documentation build.
-- [ ] Manual terminal verification sign-off.
+- [x] Linux terminal verification and approved platform waivers recorded.
 - [ ] Maintainer review and approval.
 - [x] Confirmation that pull request #41 is not included.
 
@@ -648,7 +685,7 @@ environment requiring approval, and reject publishing from a branch ref.
 - [ ] Pre-rewrite code frozen on `release/1.0.0`.
 - [ ] All release blockers resolved.
 - [ ] Version, README, changelog, and documentation updated.
-- [ ] Automated and manual validation passed.
+- [x] Automated validation passed; manual results and approved waivers recorded.
 - [ ] Release PR reviewed and merged into `main`.
 - [ ] `v1.0.0` created on the exact approved `main` commit.
 - [ ] Hex published from a clean checkout of `v1.0.0`.

--- a/test/manual/mac.md
+++ b/test/manual/mac.md
@@ -1,5 +1,92 @@
 # macOS Manual Testing Checklist
 
+> **1.0.0 status:** Interactive macOS verification was waived on 2026-08-27
+> because no macOS system was available. This checklist is retained for future
+> validation; the waiver is not a successful test result.
+
+Hosted macOS CI validates compilation and the automated suite, but it cannot
+verify the bytes emitted by a real keyboard, live window resizing, or terminal
+restoration. Complete this checklist in an interactive macOS terminal against
+the exact release commit.
+
+## Test record
+
+- Tester:
+- Date:
+- macOS version:
+- Terminal and version:
+- Elixir/OTP versions:
+- Commit (must match the intended release head):
+
+## Release-critical smoke test
+
+From the repository root:
+
+```bash
+git switch release/1.0.0
+git pull --ff-only origin release/1.0.0
+git status --porcelain
+git rev-parse HEAD
+mix deps.get
+mix compile --warnings-as-errors
+```
+
+`git status --porcelain` must print nothing. Record the commit above before
+testing.
+
+Capture the terminal mode, run the basic example, and compare the mode after a
+normal exit:
+
+```bash
+before_stty=$(stty -g)
+mix run -e 'Code.require_file("examples/multi_renderer/basic.ex"); Basic.run()'
+after_stty=$(stty -g)
+test "$before_stty" = "$after_stty"
+```
+
+- [ ] Initial content renders in the alternate screen without scrolling.
+- [ ] Arrow keys and `j`/`k` move the selection; Enter toggles details.
+- [ ] Shrinking and expanding the window redraws without stale rows or cursor
+      overflow.
+- [ ] `q` returns to a usable prompt with input echo and a visible cursor.
+- [ ] The before/after `stty` values match.
+- [ ] Repeating the run and interrupting it with Control+C restores the prompt.
+
+Verify the macOS Option+Delete path with the real TextInput example:
+
+```bash
+cd examples/text_input
+mix deps.get
+mix termui.run
+```
+
+- [ ] Typing `alpha beta` and pressing Option+Delete removes `beta` without
+      stalling later keyboard input.
+- [ ] Backspace, Delete, arrows, Home/End, Tab, and Enter behave as documented.
+- [ ] Empty the focused input and press `q` to exit cleanly.
+
+Verify IEx compatibility:
+
+```bash
+cd examples/iex_counter
+iex -S mix
+```
+
+Then run `IExCounter.App.run()`.
+
+- [ ] Arrow keys update the counter and `q` returns to the same IEx prompt.
+- [ ] The prompt remains usable and terminal echo/cursor state is restored.
+
+Run the release-critical checks in Terminal.app. Repeat them in iTerm2 if the
+release is being signed off for the guide's stated iTerm2 support. Terminal.app
+mouse limitations documented in `guides/user/08-terminal.md` are accepted and
+do not fail this gate.
+
+## Extended example matrix
+
+The following matrix records broader example coverage when time permits; it is
+not a substitute for the release-critical lifecycle checks above.
+
 | Example | Tested | Description |
 |---------|:------:|-------------|
 | alert_dialog | [ ] | Standardized message dialogs and confirmations with predefined button configurations |

--- a/test/manual/windows.md
+++ b/test/manual/windows.md
@@ -1,5 +1,11 @@
 # Windows Manual Testing Checklist
 
+> **1.0.0 status:** Interactive native Windows verification was waived on
+> 2026-08-28 because no representative system was available. Native console
+> mode, raw input, and resize remain unsupported in `1.0.0`. Retain this
+> checklist for validation after those gaps are implemented; the waiver is not
+> a successful test result.
+
 | Example | Tested | Description |
 |---------|:------:|-------------|
 | alert_dialog | [ ] | Standardized message dialogs and confirmations with predefined button configurations |

--- a/test/manual/wsl.md
+++ b/test/manual/wsl.md
@@ -1,5 +1,146 @@
 # WSL Manual Testing Checklist
 
+> **1.0.0 status:** Interactive WSL/ConPTY verification was waived on
+> 2026-08-28 because no representative system was available. This checklist is
+> retained for future validation; the waiver is not a successful test result.
+
+This gate must run inside WSL from a Windows Terminal profile so the Unix
+backend is exercised through ConPTY. Native PowerShell or Command Prompt does
+not satisfy this gate.
+
+## Test record
+
+- Tester:
+- Date:
+- Windows version:
+- Windows Terminal version:
+- WSL version and distribution:
+- Elixir/OTP versions:
+- Commit (must match the intended release head):
+
+## Windows preflight
+
+In PowerShell, record the WSL installation and confirm the distribution uses
+WSL 2:
+
+```powershell
+wsl --version
+wsl --status
+wsl --list --verbose
+```
+
+Open the distribution from Windows Terminal. In the WSL shell, run:
+
+```bash
+test -n "$WSL_DISTRO_NAME"
+test -n "$WSL_INTEROP"
+test -n "$WT_SESSION"
+tty
+printf 'TERM=%s\n' "$TERM"
+stty size
+```
+
+All three environment checks must succeed, `tty` must identify a terminal, and
+`stty size` must report non-zero rows and columns.
+
+## Repository preflight
+
+From the repository root inside WSL:
+
+```bash
+git switch release/1.0.0
+git pull --ff-only origin release/1.0.0
+git status --porcelain
+git rev-parse HEAD
+mix deps.get
+mix compile --warnings-as-errors
+mix test test/term_ui/platform_test.exs test/integration/cross_platform_test.exs
+mix run -e 'IO.inspect(%{wsl: TermUI.Platform.wsl?(), conpty: TermUI.TerminalOutput.needs_hard_reset?()})'
+```
+
+`git status --porcelain` must print nothing. Both values in the final command
+must be `true`.
+
+## Raw backend
+
+Raw mode requires OTP 28 or later. Capture and compare the terminal mode around
+the basic example:
+
+```bash
+before_stty=$(stty -g)
+mix run -e 'Code.require_file("examples/multi_renderer/basic.ex"); Basic.run(backend: :raw)'
+after_stty=$(stty -g)
+test "$before_stty" = "$after_stty"
+```
+
+- [ ] The initial alternate-screen render is clean and does not scroll.
+- [ ] Arrow keys and `j`/`k` move the selection; Enter toggles details.
+- [ ] Shrinking and expanding the Windows Terminal window redraws without
+      stale rows, wrapping artifacts, or a stuck cursor.
+- [ ] Resize followed immediately by `q` restores the prompt.
+- [ ] A normal `q` exit restores input echo, cursor visibility, colors, and the
+      exact `stty` value.
+- [ ] Repeating the run and interrupting with Control+C restores the prompt.
+
+## TTY and IEx paths
+
+Force the TTY backend from the repository root:
+
+```bash
+before_stty=$(stty -g)
+mix run -e 'Code.require_file("examples/multi_renderer/basic.ex"); Basic.run(backend: :tty)'
+after_stty=$(stty -g)
+test "$before_stty" = "$after_stty"
+```
+
+TTY input may be line-buffered; use `q` followed by Enter when necessary.
+
+- [ ] Navigation and quit input work without freezing the runtime.
+- [ ] The terminal mode matches after exit.
+
+Then verify return to IEx:
+
+```bash
+cd examples/iex_counter
+iex -S mix
+```
+
+Run `IExCounter.App.run()`, exercise arrows and reset, then quit.
+
+- [ ] The application returns to the same usable IEx prompt.
+- [ ] Echo, cursor visibility, and line editing remain correct.
+
+## Paste and ConPTY-specific behavior
+
+Run the real text-input example:
+
+```bash
+cd examples/text_input
+mix deps.get
+mix termui.run
+```
+
+- [ ] Single-line paste arrives once and contains no bracket markers.
+- [ ] Multiline paste into the multiline field preserves its line breaks.
+- [ ] Shift+Tab and modified navigation keys do not leak escape text.
+- [ ] Clicking or dragging does not print raw mouse escape sequences. Mouse
+      tracking is intentionally disabled under WSL/ConPTY in `1.0.0`.
+- [ ] Empty the focused input and press `q` to exit cleanly.
+
+## Gate result
+
+- [ ] Raw backend checks passed on OTP 28 or later.
+- [ ] TTY and IEx checks passed.
+- [ ] Resize, paste, and cleanup checks passed.
+- [ ] Any limitation or failure is recorded below and in the release notes.
+
+Notes:
+
+## Extended example matrix
+
+The matrix below records broader coverage when time permits. It is not a
+substitute for the release-critical lifecycle checks above.
+
 | Example | Tested | Description |
 |---------|:------:|-------------|
 | alert_dialog | [ ] | Standardized message dialogs and confirmations with predefined button configurations |

--- a/test/term_ui/backend/selector_test.exs
+++ b/test/term_ui/backend/selector_test.exs
@@ -5,6 +5,11 @@ defmodule TermUI.Backend.SelectorTest do
   alias TermUI.Backend.Selector
   import TermUI.Backend.SelectorTestHelpers
 
+  setup_all do
+    assert Code.ensure_loaded?(Selector)
+    :ok
+  end
+
   describe "module structure" do
     test "module compiles successfully" do
       assert Code.ensure_loaded?(Selector)

--- a/test/term_ui/integration/event_system_test.exs
+++ b/test/term_ui/integration/event_system_test.exs
@@ -113,8 +113,9 @@ defmodule TermUI.Integration.EventSystemTest do
 
       Executor.execute(executor, cmd, self(), :test)
 
-      # Should receive timeout error, not the result
-      assert_receive {:command_result, :test, _, {:error, :timeout}}, @default_timeout
+      # The executor's 50 ms deadline is the behavior under test. Give a loaded
+      # CI scheduler enough time to deliver the resulting message.
+      assert_receive {:command_result, :test, _, {:error, :timeout}}, @eventual_timeout
       refute_receive {:command_result, :test, _, :should_timeout}, @extended_timeout
     end
   end


### PR DESCRIPTION
## Summary

- records the approved live SSH, macOS, WSL/ConPTY, and native Windows waivers for 1.0.0
- preserves explicit post-1.0 verification follow-ups
- adds release-critical macOS and WSL manual procedures
- documents the existing WSL/ConPTY mouse-tracking limitation accurately

## Validation

- `mix format --check-formatted`
- `mix docs --warnings-as-errors`
- `git diff --check`

This PR records accepted release risks; it does not represent the waived environments as successfully tested.